### PR TITLE
add circle ci file to projects

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,18 @@
+machine:
+  environment:
+    PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
+    CI: true
+  node:
+    version: 9.2.1
+
+dependencies:
+  override:
+    - yarn
+  cache_directories:
+    - ~/.cache/yarn
+
+test:
+  pre:
+    - cp src/data/firebase.prod.json src/data/firebase.config.json
+  override:
+    - yarn test -t src


### PR DESCRIPTION
First half of pr for #13 

this config file has been tested on my personal fork. check out the latest commits to see the CI builds: https://github.com/ataki/raha.io/commits/master

just sent a request to enable circle ci for the `rahafoundations` org. once that's done, I can set up raha.io on CircleCI and merge this PR to start building.