### PR TITLE
add internationalization support

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-firebaseui": "^1.0.10",
+    "react-intl": "^2.4.0",
     "react-redux": "^5.0.7",
     "react-router-dom": "^4.2.2",
     "react-scripts": "1.1.1",

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import App from './App';
+import { IntlProvider } from 'react-intl'
 
 it('renders without crashing', () => {
   const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
+  ReactDOM.render(<IntlProvider locale="en"><App /></IntlProvider>, div);
 });

--- a/src/components/MemberRelations.js
+++ b/src/components/MemberRelations.js
@@ -4,9 +4,11 @@ import { OpCode } from '../operations';
 import { db } from '../firebaseInit';
 import { fetchOperations, OpMeta } from '../actions';
 import { getAuthMemberData } from '../connectors';
+import { FormattedMessage } from 'react-intl';
 import MemberThumbnail from './MemberThumbnail';
 import TrustLevel from './TrustLevel';
 import TrustButton from './TrustButton';
+import STRINGS from '../strings';
 
 interface Props {
   uid: string;
@@ -47,7 +49,8 @@ class MemberRelations extends Component<Props, State> {
       });
       sections.push(
         <div key={title} className="MemberRelations-section">
-          <div className="SectionTitle">{`${title} (${rows.length})`}</div>
+          <div className="SectionTitle">
+          <FormattedMessage {...title}  values={{value: rows.length}}/> </div>
           {rows}
         </div>
       );
@@ -77,10 +80,10 @@ class MemberRelations extends Component<Props, State> {
       if (this.canTrustThisUser()) {
         sections.push(<TrustButton key="Trust Button" toUid={this.props.uid} toMid={this.props.mid} />);
       }
-      this.addSection(sections, this.props.invitedByUids, 'Invited By');
-      this.addSection(sections, this.props.invitedUids, 'Invites');
-      this.addSection(sections, this.props.trustedByUids, 'Trusted by');
-      this.addSection(sections, this.props.trustsUids, 'Trusts');
+      this.addSection(sections, this.props.invitedByUids, STRINGS.invited_by);
+      this.addSection(sections, this.props.invitedUids, STRINGS.invites);
+      this.addSection(sections, this.props.trustedByUids, STRINGS.trusted_by);
+      this.addSection(sections, this.props.trustsUids, STRINGS.trusts);
       // Grab and calculate these values based on this.state.trustedByUids and redux store.getState().uidToMembers.
     }
     return <div>{sections}</div>;

--- a/src/components/PageNotFound.js
+++ b/src/components/PageNotFound.js
@@ -1,11 +1,14 @@
 import * as React from 'react';
 import RahaTitle from './RahaTitle';
 import { Link } from 'react-router-dom';
+import { FormattedMessage } from 'react-intl';
+import STRINGS from '../strings';
 
 const PageNotFound = () => (
   <div className="PageNotFound">
     <RahaTitle />
-    <p><strong>404</strong> page not found, go <Link to="/">home</Link>.</p>
+     <FormattedMessage {...STRINGS.page_not_found} 
+     values={{404: <strong>404</strong>, home: <Link to="/">home</Link>}} />
     <p>¯\_(ツ)_/¯</p>
   </div>
 );

--- a/src/components/RequestInviteForm.test.js
+++ b/src/components/RequestInviteForm.test.js
@@ -3,6 +3,7 @@ import * as ReactDOM from 'react-dom';
 import Enzyme, { mount } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16';
 import { RequestInviteForm } from './RequestInviteForm';
+import { IntlProvider } from 'react-intl'
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -15,8 +16,8 @@ function setup() {
     members: {},
     fetchMemberIfNeeded: async () => { {} }
   };
-
-  const enzymeWrapper = mount(<RequestInviteForm {...props} />);
+  
+  const enzymeWrapper = mount(<IntlProvider locale="en"><RequestInviteForm {...props} /></IntlProvider>);
 
   return {
     props,

--- a/src/components/RequestInviteForm.test.js
+++ b/src/components/RequestInviteForm.test.js
@@ -4,6 +4,7 @@ import Enzyme, { mount } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16';
 import { RequestInviteForm } from './RequestInviteForm';
 import { IntlProvider } from 'react-intl'
+import { mountWithIntl } from '../helpers/intl-enzyme-test-helper.js';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -17,7 +18,7 @@ function setup() {
     fetchMemberIfNeeded: async () => { {} }
   };
   
-  const enzymeWrapper = mount(<IntlProvider locale="en"><RequestInviteForm {...props} /></IntlProvider>);
+  const enzymeWrapper = mountWithIntl(<RequestInviteForm {...props} />);
 
   return {
     props,

--- a/src/components/TrustLevel.js
+++ b/src/components/TrustLevel.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import STRINGS from '../strings';
 
 // TODO only show TrustSuggestion if current user is viewing.
 // Based on the FAQ trust is determined by:
@@ -17,33 +19,35 @@ const TrustLevel = ({ ownProfile, trustLevel, networkJoinDate, trustedByLevel2, 
 const TrustSuggestion = (trustLevel, networkJoinDate, trustedByLevel2, trustedByLevel3) => {
   const MILLI_PER_DAY = 86400000;
   if (networkJoinDate > new Date().getTime() - (((trustLevel + 1) * 7) * MILLI_PER_DAY)) {
-    return <div> Stay active on the network for longer to increase your trust level</div>;
+    return <div><FormattedMessage {...STRINGS.trust_suggestion_active_longer} /></div>;
   }
   switch (trustLevel) {
     case 0:
       if (trustedByLevel2 + trustedByLevel3 < 2) {
         return (
-          <div> Increase your trust by receiving trust from at least
-      {2 - (trustedByLevel2 + trustedByLevel3)} level 2+ accounts</div>
+           <div> <FormattedMessage {...STRINGS.trust_suggestion_recieve_trust} 
+           values={{accounts: 2 - (trustedByLevel2 + trustedByLevel3), accountlevel: 2}} /></div>
         );
       }
       break;
     case 1:
       if (trustedByLevel3 < 3) {
         return (
-          <div>Increase your trust by receiving trust from at least {3 - (trustedByLevel3)} level 3 accounts</div>
+           <div> <FormattedMessage {...STRINGS.trust_suggestion_recieve_trust} 
+           values={{accounts: 3 - (trustedByLevel3), accountlevel: 3}} /></div>
         );
       }
       break;
     case 2:
       if (trustedByLevel3 < 5) {
         return (
-          <div>Increase your trust by receiving trust from at least {5 - (trustedByLevel3)} level 3 accounts</div>
+           <div> <FormattedMessage {...STRINGS.trust_suggestion_recieve_trust} 
+           values={{accounts: 5 - (trustedByLevel3), accountlevel: 3}} /></div>
         );
       }
       break;
     case 3:
-      return <div>You are max trust level</div>;
+      return <div> <FormattedMessage {...STRINGS.trust_suggestion_max} /></div>;
     default:
       return null;
   }

--- a/src/components/YoutubeVideo.js
+++ b/src/components/YoutubeVideo.js
@@ -1,4 +1,6 @@
 import React, { Component } from 'react';
+import { FormattedMessage } from 'react-intl';
+import STRINGS from '../strings';
 
 // eslint-disable-next-line no-useless-escape
 const YOUTUBE_URL_REGEX = /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#\&\?]*).*/;
@@ -20,7 +22,7 @@ export default class YoutubeVideo extends Component {
     return (
       <div className="Video">
         <object ref={v => { this.videoObject = v; }} >
-          <div>Join Video</div>
+          <div><FormattedMessage {...STRINGS.join_video} /></div>
           <param name="allowFullScreen" value="true" />
           <embed
             className="Youtube"

--- a/src/helpers/intl-enzyme-test-helper.js
+++ b/src/helpers/intl-enzyme-test-helper.js
@@ -1,0 +1,38 @@
+/**
+ * Components using the react-intl module require access to the intl context.
+ * This is not available when mounting single components in Enzyme.
+ * These helper functions aim to address that and wrap a valid,
+ * English-locale intl context around them.
+ */
+
+import React from 'react';
+import { IntlProvider, intlShape } from 'react-intl';
+import { mount, shallow } from 'enzyme';
+
+// You can pass your messages to the IntlProvider. Optional: remove if unneeded.
+// const messages = require('../locale/en'); // en.json
+
+// Create the IntlProvider to retrieve context for wrapping around.
+const intlProvider = new IntlProvider({ locale: 'en'}, {});
+const { intl } = intlProvider.getChildContext();
+
+/**
+ * When using React-Intl `injectIntl` on components, props.intl is required.
+ */
+function nodeWithIntlProp(node) {
+  return React.cloneElement(node, { intl });
+}
+
+/**
+ * Export these methods.
+ */
+export function shallowWithIntl(node) {
+  return shallow(nodeWithIntlProp(node), { context: { intl } });
+}
+
+export function mountWithIntl(node) {
+  return mount(nodeWithIntlProp(node), {
+    context: { intl },
+    childContextTypes: { intl: intlShape }
+  });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,5 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
+import { IntlProvider } from 'react-intl'
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(<IntlProvider locale="en"><App /></IntlProvider>, document.getElementById('root'));

--- a/src/strings.js
+++ b/src/strings.js
@@ -1,0 +1,47 @@
+import { defineMessages } from 'react-intl';
+
+const STRINGS = defineMessages({
+    invited_by: {
+        id: 'invited_by',
+        defaultMessage: 'Invited By ({value})',
+    },
+    invites: {
+        id: 'invites',
+        defaultMessage: 'Invites ({value})',
+    },
+    trusted_by: {
+        id: 'trusted_by',
+        defaultMessage: 'Trusted By ({value})',
+    },
+    trusts: {
+        id: 'trusts',
+        defaultMessage: 'Trusts ({value})',
+    },
+    loading: {
+        id: 'loading',
+        defaultMessage: 'Loading',
+    },    
+    join_video: {
+        id: 'join_video',
+        defaultMessage: 'Join Video',
+    },
+    page_not_found: {
+        id: 'page_not_found',
+        defaultMessage: '{404} page not found, go {home}.',
+    },
+    // Trust Level Strings
+    trust_suggestion_active_longer: {
+        id: 'trust_suggestion_active_longer',
+        defaultMessage: 'Stay active on the network for more days to increase your trust level.',
+    },
+    trust_suggestion_recieve_trust: {
+        id: 'trust_suggestion_recieve_trust',
+        defaultMessage: 'Increase your trust by receiving trust from {accounts} level {accountlevel}+ accounts.',
+    },
+    trust_suggestion_max: {
+        id: 'trust_suggestion_max',
+        defaultMessage: 'You are max trust level.',
+    },
+});
+
+export default STRINGS;


### PR DESCRIPTION
Added use of the Library https://github.com/yahoo/react-intl for internationalization support. Currently only english support but allows us to store strings in a separate file that can also be translated later as we want to support more languages.  
issue #26 