### PR TITLE
Modify the invite flow.

### DIFF
--- a/src/components/AppRouter.js
+++ b/src/components/AppRouter.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter, Switch, Route } from 'react-router-dom';
+import { BrowserRouter, Switch, Redirect, Route } from 'react-router-dom';
 import CodeOfConduct from './CodeOfConduct';
 import LogIn from './LogIn';
 import LogOut from './LogOut';
@@ -18,7 +18,7 @@ function AppRouter() {
           <Route path="/login" component={LogIn} />
           <Route path="/logout" component={LogOut} />
           <Route path="/code-of-conduct" component={CodeOfConduct} />
-          <Route path="/me" component={Profile} />
+          <Route path="/me" render={() => (<Redirect to='/login' replace />)} />
           <Route path="/m/:memberId/invite" component={RequestInvite} />
           <Route path="/m/:memberId" component={Profile} />
           <Route component={PageNotFound} />

--- a/src/components/LogIn.js
+++ b/src/components/LogIn.js
@@ -1,21 +1,37 @@
 import * as React from 'react';
+import { connect } from 'react-redux';
+import { Redirect } from 'react-router-dom';
 import * as firebase from 'firebase';
 import { FirebaseAuth } from 'react-firebaseui';
-import { auth } from '../firebaseInit';
 
-const LogIn = ({ noRedirect }) => {
+import { auth } from '../firebaseInit';
+import { getAuthMemberDoc } from '../connectors';
+
+const LogIn = ({ authMemberDoc, noRedirect }) => {
   const uiConfig = {
     signInFlow: 'popup',
     signInOptions: [
       firebase.auth.FacebookAuthProvider.PROVIDER_ID,
       firebase.auth.GoogleAuthProvider.PROVIDER_ID,
       firebase.auth.GithubAuthProvider.PROVIDER_ID,
-    ]
+    ], callbacks: {
+      signInSuccess: () => {
+        return false;
+      }
+    },
   };
-  if (!noRedirect) {
-    uiConfig.signInSuccessUrl = '/me';
+  if (authMemberDoc) {
+    return (
+      <Redirect to={`/m/${authMemberDoc.get('mid')}`} replace />
+    )
+  } else {
+    return <FirebaseAuth uiConfig={uiConfig} firebaseAuth={auth} />;
   }
-  return <FirebaseAuth uiConfig={uiConfig} firebaseAuth={auth} />;
 };
 
-export default LogIn;
+function mapStateToProps(state, ownProps) {
+  const authMemberDoc = getAuthMemberDoc(state);
+  return { authMemberDoc };
+}
+
+export default connect(mapStateToProps)(LogIn);

--- a/src/components/LogIn.js
+++ b/src/components/LogIn.js
@@ -16,11 +16,13 @@ const LogIn = ({ authMemberDoc, noRedirect }) => {
       firebase.auth.GithubAuthProvider.PROVIDER_ID,
     ], callbacks: {
       signInSuccess: () => {
+        // Prevent FirebaseAuth from redirecting on success.
+        // We handle redirect manually below.
         return false;
       }
     },
   };
-  if (authMemberDoc) {
+  if (authMemberDoc && !noRedirect) {
     return (
       <Redirect to={`/m/${authMemberDoc.get('mid')}`} replace />
     )

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
 import MemberRelations from './MemberRelations';
 import YoutubeVideo from './YoutubeVideo';
@@ -21,6 +22,20 @@ class Profile extends Component<Props> {
     } else if (nextProps.isMyProfile && nextProps.authFirebaseUser) {
       this.props.fetchMemberByUidIfNeeded(nextProps.authFirebaseUser.uid);
     }
+  }
+
+  renderInviteInstructions() {
+    const inviteUrl = `${window.location.origin}/m/${this.props.authMemberDoc.get('mid')}/invite`;
+    return (
+      <div>
+        <FormattedMessage id="invite_others_instructions" values={{
+          github_issue: <a href="https://github.com/rahafoundation/raha.io/issues">Github Issue</a>,
+          full_name: this.props.authMemberDoc.get('full_name'),
+          invite_link: <a href={inviteUrl}>{inviteUrl}</a>,
+          ideas_email: <a href="mailto:ideas@raha.io?subject=Raha%20Improvement">ideas@raha.io</a>,
+        }}/>
+      </div>
+    );
   }
 
   render() {
@@ -58,6 +73,8 @@ class Profile extends Component<Props> {
     return (
       <div>
         <div className="Green MemberName">{fullName}</div>
+        <h3>Invite instructions</h3>
+        {this.renderInviteInstructions()}
         {youtubeUrl && <YoutubeVideo youtubeUrl={youtubeUrl} />}
         <MemberRelations uid={memberDoc.id} mid={memberDoc.get('mid')} />
       </div>

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
 import MemberRelations from './MemberRelations';
 import YoutubeVideo from './YoutubeVideo';

--- a/src/components/RequestInvite.js
+++ b/src/components/RequestInvite.js
@@ -105,6 +105,7 @@ export class RequestInvite extends Component {
     );
   }
 
+<<<<<<< HEAD
   renderInviteInstructions() {
     const inviteUrl = `${window.location.origin}/m/${this.props.authMemberDoc.get('mid')}/invite`;
     return (
@@ -115,6 +116,25 @@ export class RequestInvite extends Component {
           invite_link: <a href={inviteUrl}>{inviteUrl}</a>,
           ideas_email: <a href="mailto:ideas@raha.io?subject=Raha%20Improvement">ideas@raha.io</a>,
         }}/>
+=======
+  renderDirections() {
+    return (
+      <div>
+        <div>
+          We are excited to have you become a member of the Raha.io Network!
+          Joining is and always will be <b>completely free</b>. You must be
+          invited by an existing member in person via video using your full name.
+          Part of the value of Raha.io Network is that it's a unique identity
+          platform. If you sign up a fake identity or have multiple accounts, or invite
+          people with fake/duplicate accounts, your account will be frozen. If you know
+          of any fake accounts, report them to increase your income level! Ultimate
+          decisions of legitimacy will be made by the Raha.io Board.
+          Only accept an invite if you trust this member and share similar values, because
+          they will be your default admin in the event you need to recover your
+          account and default representantive to select your vote for the Raha.io Board. If it turns out
+          they invited many fake or duplicate accounts, then your account is at risk of being flagged.
+        </div>
+>>>>>>> Move invite instructions to Profile.
       </div>
     );
   }
@@ -135,15 +155,19 @@ export class RequestInvite extends Component {
       // TODO the loading appears again breifly is user goes from logged out to signed in with this.renderLogIn()
       return <div>Loading</div>;
     }
-    if (this.props.authMemberDoc && this.props.authMemberDoc.get('invite_confirmed')) {
-      return this.renderInviteInstructions();
-    }
     return (
       <div>
+<<<<<<< HEAD
         <b>{<FormattedMessage id="request_invite" />}</b>
         <div>
           <FormattedMessage id="invite_me_intro" values={{completely_free: <b><FormattedMessage id="completely_free" /></b>}} />
         </div>
+=======
+        <b>Request Invite from <i>
+          {this.props.isToMemberDocLoaded ? this.props.toMemberDoc.get('full_name') : null} ({this.props.memberId})
+        </i></b>
+        {this.renderDirections()}
+>>>>>>> Move invite instructions to Profile.
         {this.props.notSignedIn ? this.renderLogIn() : (this.props.isAuthLoaded ? this.renderForm() : <div>Loading</div>)}
       </div >
     );
@@ -153,23 +177,32 @@ export class RequestInvite extends Component {
 function mapStateToProps(state, ownProps) {
   const memberId = ownProps.match.params.memberId;
   const isAuthLoaded = state.auth.isLoaded;
+  const toMemberDoc = getMemberDocByMid(state, memberId);
+
+  const stateToPropsMap = {
+    isAuthLoaded,
+    memberId,
+    isToMemberDocLoaded: toMemberDoc && !toMemberDoc.isFetching,
+    toMemberDoc,
+    notSignedIn: true,
+  };
+
   if (!isAuthLoaded) {
-    return { isAuthLoaded, memberId };
+    return stateToPropsMap;
   }
   const authFirebaseUser = state.auth.firebaseUser;
   if (!authFirebaseUser) {
-    return { isAuthLoaded, memberId, notSignedIn: true };
+    return stateToPropsMap;
   }
   const authMember = state.members.byUid[authFirebaseUser.uid];
-  return {
-    isAuthLoaded,
-    authFirebaseUser,
-    memberId,
-    isAuthMemberDocLoaded: authMember && !authMember.isFetching,
-    authMemberDoc: getAuthMemberDoc(state),
-    fullName: state.auth.firebaseUser.displayName,
-    toMemberDoc: getMemberDocByMid(state, ownProps.match.params.memberId)
-  };
+
+  stateToPropsMap.notSignedIn = false;
+  stateToPropsMap.authFirebaseUser = authFirebaseUser;
+  stateToPropsMap.isAuthMemberDocLoaded = authMember && !authMember.isFetching;
+  stateToPropsMap.authMemberDoc = getAuthMemberDoc(state);
+  stateToPropsMap.fullName = state.auth.firebaseUser.displayName;
+
+  return stateToPropsMap;
 }
 
 export default connect(

--- a/src/components/RequestInvite.js
+++ b/src/components/RequestInvite.js
@@ -105,40 +105,6 @@ export class RequestInvite extends Component {
     );
   }
 
-<<<<<<< HEAD
-  renderInviteInstructions() {
-    const inviteUrl = `${window.location.origin}/m/${this.props.authMemberDoc.get('mid')}/invite`;
-    return (
-      <div>
-        <FormattedMessage id="invite_others_instructions" values={{
-          github_issue: <a href="https://github.com/rahafoundation/raha.io/issues">Github Issue</a>,
-          full_name: this.props.authMemberDoc.get('full_name'),
-          invite_link: <a href={inviteUrl}>{inviteUrl}</a>,
-          ideas_email: <a href="mailto:ideas@raha.io?subject=Raha%20Improvement">ideas@raha.io</a>,
-        }}/>
-=======
-  renderDirections() {
-    return (
-      <div>
-        <div>
-          We are excited to have you become a member of the Raha.io Network!
-          Joining is and always will be <b>completely free</b>. You must be
-          invited by an existing member in person via video using your full name.
-          Part of the value of Raha.io Network is that it's a unique identity
-          platform. If you sign up a fake identity or have multiple accounts, or invite
-          people with fake/duplicate accounts, your account will be frozen. If you know
-          of any fake accounts, report them to increase your income level! Ultimate
-          decisions of legitimacy will be made by the Raha.io Board.
-          Only accept an invite if you trust this member and share similar values, because
-          they will be your default admin in the event you need to recover your
-          account and default representantive to select your vote for the Raha.io Board. If it turns out
-          they invited many fake or duplicate accounts, then your account is at risk of being flagged.
-        </div>
->>>>>>> Move invite instructions to Profile.
-      </div>
-    );
-  }
-
   render() {
     if (this.state.submitted) {
       // TODO this will move into <ProfilePending /> component shown at /me
@@ -157,17 +123,13 @@ export class RequestInvite extends Component {
     }
     return (
       <div>
-<<<<<<< HEAD
-        <b>{<FormattedMessage id="request_invite" />}</b>
+        <b>{<FormattedMessage id="request_invite" values={{
+          full_name: this.props.isToMemberDocLoaded ? this.props.toMemberDoc.get('full_name') : null,
+          mid: this.props.memberId
+        }} />}</b>
         <div>
           <FormattedMessage id="invite_me_intro" values={{completely_free: <b><FormattedMessage id="completely_free" /></b>}} />
         </div>
-=======
-        <b>Request Invite from <i>
-          {this.props.isToMemberDocLoaded ? this.props.toMemberDoc.get('full_name') : null} ({this.props.memberId})
-        </i></b>
-        {this.renderDirections()}
->>>>>>> Move invite instructions to Profile.
         {this.props.notSignedIn ? this.renderLogIn() : (this.props.isAuthLoaded ? this.renderForm() : <div>Loading</div>)}
       </div >
     );

--- a/src/data/locales/en.json
+++ b/src/data/locales/en.json
@@ -10,7 +10,7 @@
   "loading": "Loading",
   "join_video": "Join Video",
   "page_not_found": "{404} page not found, go {home}.",
-  "request_invite": "Request Invite",
+  "request_invite": "Request Invite from {full_name} ({mid})",
   "sign_up_above": "Sign up above to continue. We do not ask for your contact's information or ability to post.",
   "trust_suggestion_active_longer": "Stay active on the network for more days to increase your trust level.",
   "trust_suggestion_recieve_trust": "Increase your trust by receiving trust from {accounts} level {accountlevel}+ accounts.",


### PR DESCRIPTION
/login redirects to the profile page if the user is already logged in.

/me redirects to login. This has the indirect effect of /me redirecting
to the profile page if the user is already logged in.

Move invite instructions to Profile.

Addresses the first three bullets of #55.