### PR TITLE
Do jest setup automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "use-test-db": "cp src/data/firebase.test.json src/data/firebase.config.json",
     "start": "react-scripts-ts start",
     "build": "react-scripts-ts build",
-    "test": "react-scripts-ts test --env=jsdom --setupTestFrameworkScriptFile=jest-localstorage-mock",
+    "test": "react-scripts-ts test --env=jsdom",
     "eject": "react-scripts-ts eject"
   },
   "license": "Apache-2.0",

--- a/src/components/RequestInvite.test.tsx
+++ b/src/components/RequestInvite.test.tsx
@@ -1,15 +1,12 @@
 // TODO: seems odd that we need to test this by running everything, including intl
 // and more than just shallow rendering.
-import * as Enzyme from "enzyme";
-import * as Adapter from "enzyme-adapter-react-16";
+import { shallow } from "enzyme";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
 import { mountWithIntl } from "../helpers/intl-enzyme-test-helper";
 import { OperationData } from "../operations";
 import { RequestInvite } from "./RequestInvite";
-
-Enzyme.configure({ adapter: new Adapter() });
 
 // ref: pattern for testing connected components
 function setup() {
@@ -46,7 +43,7 @@ function setup() {
     }
   };
 
-  const enzymeWrapper = Enzyme.shallow(<RequestInvite {...props} />);
+  const enzymeWrapper = shallow(<RequestInvite {...props} />);
 
   return {
     props,

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,6 @@
+import 'jest-localstorage-mock';
+import * as Enzyme from 'enzyme';
+import * as Adapter from 'enzyme-adapter-react-16';
+
+// Setup adapter to work with enzyme 3.2.0
+Enzyme.configure({ adapter: new Adapter() });


### PR DESCRIPTION
The whole adapter thing sucks, so don't let it suck. Also, adding most flags to `react-scripts test` are not supported; what we did was actually messing up the default test runner.